### PR TITLE
Add arguments to enable eval function to work

### DIFF
--- a/examples/run_classifier_with_multi_stage_eval.py
+++ b/examples/run_classifier_with_multi_stage_eval.py
@@ -587,11 +587,11 @@ def compute_metrics(task_name, preds, labels):
     else:
         raise KeyError(task_name)
 
-def dev_and_training_evaluation(processor, args, label_list, tokenizer, output_mode, device, global_step, model):
-    dataset_evaluation("train", processor, args, label_list, tokenizer, output_mode, device, global_step, model)
-    dataset_evaluation("dev", processor, args, label_list, tokenizer, output_mode, device, global_step, model)
+def dev_and_training_evaluation(processor, args, label_list, tokenizer, output_mode, device, global_step, model, num_labels, task_name):
+    dataset_evaluation("train", processor, args, label_list, tokenizer, output_mode, device, global_step, model, num_labels, task_name)
+    dataset_evaluation("dev", processor, args, label_list, tokenizer, output_mode, device, global_step, model, num_labels, task_name)
 
-def dataset_evaluation(eval_type, processor, args, label_list, tokenizer, output_mode, device, global_step, model):
+def dataset_evaluation(eval_type, processor, args, label_list, tokenizer, output_mode, device, global_step, model, num_labels, task_name):
     if eval_type == "train":
         eval_examples = processor.get_train_examples(args.data_dir)
     else:
@@ -970,7 +970,7 @@ def main():
                     global_step += 1
             
             #### EVERY STAGE EVAL #####
-            dev_and_training_evaluation(processor, args, label_list, tokenizer, output_mode, device, global_step, model)
+            dev_and_training_evaluation(processor, args, label_list, tokenizer, output_mode, device, global_step, model, num_labels, task_name)
             #### EVERY STAGE EVAL END #####
 
     if args.do_train and (args.local_rank == -1 or torch.distributed.get_rank() == 0):


### PR DESCRIPTION
Some unassigned variables were referenced in the evaluation code before assignment. They have been passed as arguments to this argument to fix this issue.